### PR TITLE
Add binary search to get bucket for node

### DIFF
--- a/evm/p2p/kademlia.py
+++ b/evm/p2p/kademlia.py
@@ -193,7 +193,7 @@ class KBucket:
 
     def __le__(self, other):
         if not isinstance(other, self.__class__):
-            return super(KBucket, self).__le__(other)
+            raise TypeError("Cannot compare KBucket with type {}.".format(other.__class__))
         return self.end <= other.end
 
 
@@ -271,10 +271,12 @@ class RoutingTable:
 def binary_get_bucket_for_node(buckets, node):
     """Return the bucket for a given node."""
     sorted_buckets = sorted(buckets)
-    bucket_ends = list(KBucket.end for KBucket in sorted_buckets)
+    bucket_ends = [bucket.end for bucket in sorted_buckets]
     bucket_position = bisect.bisect_left(bucket_ends, node.id)
     # Prevents edge cases where bisect_left returns an out of range index
-    if bucket_position >= len(buckets):
+    try:
+        bucket = sorted_buckets[bucket_position]
+    except IndexError:
         raise ValueError("No bucket found for node with id {}".format(node.id))
     bucket = sorted_buckets[bucket_position]
     if not bucket.start <= node.id <= bucket.end:

--- a/evm/p2p/kademlia.py
+++ b/evm/p2p/kademlia.py
@@ -191,10 +191,13 @@ class KBucket:
     def __len__(self):
         return len(self.nodes)
 
-    def __le__(self, other):
+    def __lt__(self, other):
         if not isinstance(other, self.__class__):
             raise TypeError("Cannot compare KBucket with type {}.".format(other.__class__))
-        return self.end <= other.end
+        # Check for invalid state of KBuckets
+        if not self.end < other.start:
+            raise ValueError("Invalid Buckets.")
+        return self.end < other.start
 
 
 class RoutingTable:
@@ -270,15 +273,14 @@ class RoutingTable:
 
 def binary_get_bucket_for_node(buckets, node):
     """Return the bucket for a given node."""
-    sorted_buckets = sorted(buckets)
-    bucket_ends = [bucket.end for bucket in sorted_buckets]
+    bucket_ends = [bucket.end for bucket in buckets]
     bucket_position = bisect.bisect_left(bucket_ends, node.id)
     # Prevents edge cases where bisect_left returns an out of range index
     try:
-        bucket = sorted_buckets[bucket_position]
+        bucket = buckets[bucket_position]
     except IndexError:
         raise ValueError("No bucket found for node with id {}".format(node.id))
-    bucket = sorted_buckets[bucket_position]
+    bucket = buckets[bucket_position]
     if not bucket.start <= node.id <= bucket.end:
         raise ValueError("No bucket found for node with id {}".format(node.id))
     return bucket

--- a/evm/p2p/kademlia.py
+++ b/evm/p2p/kademlia.py
@@ -194,9 +194,6 @@ class KBucket:
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
             raise TypeError("Cannot compare KBucket with type {}.".format(other.__class__))
-        # Check for invalid state of KBuckets
-        if not self.end < other.start:
-            raise ValueError("Invalid Buckets.")
         return self.end < other.start
 
 
@@ -272,18 +269,16 @@ class RoutingTable:
 
 
 def binary_get_bucket_for_node(buckets, node):
-    """Return the bucket for a given node."""
+    """Given a list of ordered buckets, returns the bucket for a given node."""
     bucket_ends = [bucket.end for bucket in buckets]
     bucket_position = bisect.bisect_left(bucket_ends, node.id)
     # Prevents edge cases where bisect_left returns an out of range index
     try:
         bucket = buckets[bucket_position]
-    except IndexError:
+        assert bucket.start <= node.id <= bucket.end
+        return bucket
+    except (IndexError, AssertionError):
         raise ValueError("No bucket found for node with id {}".format(node.id))
-    bucket = buckets[bucket_position]
-    if not bucket.start <= node.id <= bucket.end:
-        raise ValueError("No bucket found for node with id {}".format(node.id))
-    return bucket
 
 
 class KademliaProtocol:

--- a/evm/p2p/test_kademlia.py
+++ b/evm/p2p/test_kademlia.py
@@ -269,7 +269,7 @@ def test_bucket_ordering():
     third = random_node()
     assert first < second
     with pytest.raises(TypeError):
-            first > third
+        first > third
 
 
 @pytest.mark.parametrize(

--- a/evm/p2p/test_kademlia.py
+++ b/evm/p2p/test_kademlia.py
@@ -264,13 +264,16 @@ def test_kbucket_split():
 
 
 def test_bucket_ordering():
-    first = kademlia.KBucket(51,100)
+    first = kademlia.KBucket(51, 100)
     second = kademlia.KBucket(0, 50)
+    third = random_node()
     assert first > second
- 
+    with pytest.raises(TypeError):
+            first > third
+
 
 @pytest.mark.parametrize(
-    "bucket_list, node_id, correct", 
+    "bucket_list, node_id, correct",
     (
         (list([]), 5, None),
         # test for node.id < bucket.end
@@ -278,12 +281,25 @@ def test_bucket_ordering():
         # test for node.id > bucket.start
         (list([kademlia.KBucket(6, 10)]), 5, None),
         # test multiple buckets that don't contain node.id
-        (list([kademlia.KBucket(0, 1), kademlia.KBucket(50, 100), kademlia.KBucket(6, 49)]), 5, None),
+        (list(
+            [
+                kademlia.KBucket(0, 1),
+                kademlia.KBucket(50, 100),
+                kademlia.KBucket(6, 49)
+            ]
+        ), 5, None),
         # test single bucket
         (list([kademlia.KBucket(0, 100)]), 5, 0),
         (list([kademlia.KBucket(50, 100), kademlia.KBucket(0, 49)]), 5, 1),
         # test multiple unordered buckets
-        (list([kademlia.KBucket(50, 100), kademlia.KBucket(0, 1), kademlia.KBucket(2, 5), kademlia.KBucket(6, 49) ]), 5, 2),
+        (list(
+            [
+                kademlia.KBucket(50, 100),
+                kademlia.KBucket(0, 1),
+                kademlia.KBucket(2, 5),
+                kademlia.KBucket(6, 49)
+            ]
+        ), 5, 2),
     )
 )
 def test_binary_get_bucket_for_node(bucket_list, node_id, correct):


### PR DESCRIPTION
### What was wrong?
Change get bucket for node search from linear to binary

### How was it fixed?
Used total_ordering and bisect modules

#### Cute Animal Picture
![giphy-downsized-large 3](https://user-images.githubusercontent.com/9753150/30231419-04956b02-94a8-11e7-8fa7-415b1f9a5759.gif)
